### PR TITLE
feat: Add environment variables and example usage scripts

### DIFF
--- a/TEMPLATE/pixi.toml.jinja
+++ b/TEMPLATE/pixi.toml.jinja
@@ -11,6 +11,17 @@ platforms = ["osx-arm64", "linux-64", "win-64", "osx-64"]
 quality = { features = ["quality"], solve-group = "default" }
 docs = { features = ["docs"], solve-group = "default" }
 
+[activation]
+# convenient variables which can be used in scripts
+env.CONFIG = "${PIXI_PROJECT_ROOT}/config"
+env.METADATA = "${PIXI_PROJECT_ROOT}/metadata"
+env.LOGS = "${PIXI_PROJECT_ROOT}/logs"
+env.RAWDATA = "${PIXI_PROJECT_ROOT}/data/rawdata"
+env.PROCDATA = "${PIXI_PROJECT_ROOT}/data/procdata"
+env.RESULTS = "${PIXI_PROJECT_ROOT}/data/results"
+env.SCRIPTS = "${PIXI_PROJECT_ROOT}/workflow/scripts"
+
+
 [dependencies]
 python = ">={{ python_version }}"
 ipython = "*"

--- a/TEMPLATE/pixi.toml.jinja
+++ b/TEMPLATE/pixi.toml.jinja
@@ -28,6 +28,10 @@ ipython = "*"
 ipykernel = "*"
 jupyterlab = "*"
 pip = "*"
+
+[tasks]
+example_script = {cmd="python $SCRIPTS/example_script.py"}
+
 ############################################## QUALITY ###############################################
 # Quality includes linting, type checking, and formatting
 [feature.quality.dependencies]

--- a/TEMPLATE/workflow/notebooks/example_notebook.ipynb
+++ b/TEMPLATE/workflow/notebooks/example_notebook.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "442beff9",
+   "metadata": {},
+   "source": [
+    "# Example Notebook\n",
+    "\n",
+    "This is just a quick example showing how to use the template."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "75fde9f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(\n",
+    "\tlevel=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s'\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2d08bd5d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-05-09 13:20:53,996 - INFO - PIXI_PROJECT_ROOT: /Users/bhklab/dev/bhklab/testdirs/another-example has 20 files\n",
+      "2025-05-09 13:20:53,997 - INFO - RAWDATA: data/rawdata has 0 files\n",
+      "2025-05-09 13:20:53,998 - INFO - PROCDATA: data/procdata has 0 files\n",
+      "2025-05-09 13:20:53,998 - INFO - SCRIPTS: workflow/scripts has 0 files\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "env_dir_variables = [\n",
+    "    'PIXI_PROJECT_ROOT',\n",
+    "    'RAWDATA',\n",
+    "    'PROCDATA',\n",
+    "    'SCRIPTS',\n",
+    "]\n",
+    "\n",
+    "for var in env_dir_variables:\n",
+    "    var_path = Path(os.environ.get(var))\n",
+    "    logger.info(f'{var}: {var_path} has {len(list(var_path.glob(\"*\")))} files')\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac1f9617",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "default",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/TEMPLATE/workflow/scripts/example_script.py
+++ b/TEMPLATE/workflow/scripts/example_script.py
@@ -1,0 +1,27 @@
+import logging
+import os
+from pathlib import Path
+
+logging.basicConfig(
+	level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s'
+)
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+	# examples of template defined env variables
+	env_dir_variables = [
+		'RAWDATA',
+		'PROCDATA',
+		'SCRIPTS',
+	]
+
+	for var in env_dir_variables:
+		var_path = Path(os.environ.get(var))
+		logger.info(f'{var}: {var_path} has {len(list(var_path.glob("*")))} files')
+
+
+if __name__ == '__main__':
+	logger.info(f'Starting example script from {Path().cwd()=}')
+	main()


### PR DESCRIPTION
### proof of concept 

- introduce activation environment variables for convenience and provide an example script and notebook to demonstrate their usage.

how I handle not having to do a bunch of "../../rawdata/" across different parts of my work and being able to use the same interface in both jupyter notebooks whose working directory is their parent, whereas running scripts consider the working directory theyre called from

+ then all of a sudden moving any files around messes things up

notes:
- I have a strong feeling this does not work on windows Powershell lol
    - looks like this template itself is going to need some github action testing across systems lol 
- future work can probably setup a super simple python package that handles this stuff ti simplify the whole `os.environ` steps 
- this feature should not be used in to source python modules for utility functions or similar, and instead should take the `python-packaged src` approach in #7 which is very much a wip 
