### PR TITLE
refactor: updating python and damply template dependecy setup

### DIFF
--- a/TEMPLATE/pixi.toml.jinja
+++ b/TEMPLATE/pixi.toml.jinja
@@ -24,14 +24,14 @@ env.RESULTS = "${PIXI_PROJECT_ROOT}/data/results"
 env.SCRIPTS = "${PIXI_PROJECT_ROOT}/workflow/scripts"
 
 [dependencies]
-python = ">={{ python_version }}"
+python = "=={{ python_version }}"
 ipython = "*"
 ipykernel = "*"
 jupyterlab = "*"
 pip = "*"
 
 [pypi-dependencies]
-damply = ">=0.10.0, <0.11"
+damply = ">=0.26.0"
 
 [tasks]
 example_script = {cmd="python $SCRIPTS/example_script.py", description="Run an example script"}


### PR DESCRIPTION
In the pixi.toml for the template, the python dependency was set to `python = ">={{ python_version }}"`, which always ended up installing the latest version of python, even if you wanted 3.11 or 3.12.

Other update is for damply version, set to latest v0.26.0